### PR TITLE
Fix checkUserToken method in api

### DIFF
--- a/src/components/services/api.ts
+++ b/src/components/services/api.ts
@@ -139,13 +139,16 @@ class Api {
       }
     );
     const data: IUserSignInResp = await res.json();
+    localStorage.setItem('userToken', `${data.token}`);
+    localStorage.setItem('userRefreshToken', `${data.refreshToken}`);
     return data;
   }
 
+  // eslint-disable-next-line consistent-return
   public async checkUserTokens(
     id: string,
     refreshToken: string
-  ): Promise<void> {
+  ): Promise<boolean> {
     const res = await fetch(
       `${this.domain}/${Path.USERS}/${id}/${Path.TOKENS}/check`,
       {
@@ -156,10 +159,13 @@ class Api {
         },
       }
     );
-    const result: boolean = await res.json();
-
-    if (result) {
-      this.getNewUserTokens(id, refreshToken);
+    if (res.ok) {
+      const result: boolean = await res.json();
+      if (result) {
+        this.getNewUserTokens(id, refreshToken);
+      }
+    } else {
+      return false;
     }
   }
 


### PR DESCRIPTION
Тесты показали, что не так понял логику сервера, думал что через refresh токен можно обновить в любой момент, однако выходит так, что обычный токен работает 4 часа, а refresh токен 4,5 часа, т.е. если запросов не будет в течение этих получаса, то refresh токен тоже закончиться и нужно будет выводить попап авторизации.
Следовательно логика слегка переделана так, что метод checkUserTokens своим запросом на сервер будет там же проверять находимся ли мы в момент запроса в этих 30 минутах, если да, то запускает метод для обновления токена, если нет, то ничего не делает. Но если запросов не будет в течение этих 30 минут, то метод вернет ошибку 401 и вернет false, что будет нам говорить о необходимости вывести пользователю попап авторизации, т.к. оба токена закончились.
Поэтому снова обновите локальный репо кому нужно